### PR TITLE
GDB-11239: Add Internationalization to GraphiQL

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -18,7 +18,8 @@
     "**/package.json",
     "**/esbuild.js",
     ".eslintrc.js",
-    ".vscode/extensions.json"
+    ".vscode/extensions.json",
+    "packages/graphiql-react/src/assets/**/*.json"
   ],
   "files": ["**/*.{js,cjs,mjs,ts,jsx,tsx,md,mdx,html,json,css,toml,yaml,yml}"]
 }

--- a/packages/graphiql-react/src/assets/i18n/en.json
+++ b/packages/graphiql-react/src/assets/i18n/en.json
@@ -1,0 +1,113 @@
+{
+  "graphiql": {
+    "sidebar": {
+      "btn": {
+        "refresh_graphql_schema": "Re-fetch GraphQL schema",
+        "open_short_keys_dialog": "Open short keys dialog",
+        "open_settings_dialog": "Open settings dialog"
+      }
+    },
+    "editor": {
+      "tools": {
+        "btn": {
+          "variables": {
+            "label": "Variables"
+          },
+          "headers": {
+            "label": "Headers"
+          },
+          "open_editor": {
+            "tooltip": "Show editor tools"
+          },
+          "close_editor": {
+            "tooltip": "Hide editor tools"
+          }
+        }
+      }
+    },
+    "toolbar": {
+      "btn": {
+        "copy_query": {
+          "tooltip": "Copy query (Shift-Ctrl-C)"
+        },
+        "merge_fragment": {
+          "tooltip": "Merge fragments into query (Shift-Ctrl-M)"
+        },
+        "prettify_query": {
+          "tooltip": "Prettify query (Shift-Ctrl-P)"
+        },
+        "execute_query": {
+          "tooltip": "Execute query (Ctrl-Enter)"
+        },
+        "stop_query": {
+          "tooltip": "Stop query (Ctrl-Enter)"
+        }
+      }
+    }
+  },
+  "dialog": {
+    "settings": {
+      "title": "Settings",
+      "language": {
+        "title": "Language",
+        "description": "Select your preferred language.",
+        "btn": {
+          "language_selector": {
+            "aria_label": "Current language: English (click to change)",
+            "item_aria_label": "Select English as the current language"
+          }
+        }
+      },
+      "persisted_headers": {
+        "title": "Persist headers",
+        "description": "Save headers upon reloading. <span class=\"graphiql-warning-text\">Only enable if you trust this device.</span>",
+        "btn": {
+          "on": "On",
+          "off": "Off"
+        }
+      },
+      "theme": {
+        "title": "Theme",
+        "description": "Adjust how the interface appears.",
+        "btn": {
+          "system": "System",
+          "light": "Light",
+          "dark": "Dark"
+        }
+      },
+      "clear_storage": {
+        "title": "Clear storage",
+        "description": "Remove all locally stored data and start fresh.",
+        "btn": {
+          "clear_data": "Clear data",
+          "cleared_data": "Cleared data",
+          "error": "Failed"
+        }
+      }
+    },
+    "short_keys": {
+      "title": "Short Keys",
+      "header": {
+        "short_key": "Short key",
+        "function": "Function"
+      },
+      "function": {
+        "search_in_editor": "Search in editor",
+        "search_in_documentation": "Search in documentation",
+        "execute_query": "Execute query",
+        "prettify_editors": "Prettify editors",
+        "merge_fragments_into_definition": "Merge fragments definitions into operation definition",
+        "copy_query": "Copy query",
+        "refresh_schema": "Re-fetch schema using introspection"
+      },
+      "footer": "The editors use <a href=\"https://codemirror.net/5/doc/manual.html#keymaps\" target=\"_blank\" rel=\"noopener noreferrer\" >CodeMirror Key Maps</a> that add more short keys. This instance of Graph<em>i</em>QL uses <code>{{keyMap}}</code>."
+    }
+  },
+  "component": {
+    "add_tab": {
+      "btn": {
+        "tooltip": "Add tab"
+      }
+    }
+  }
+}

--- a/packages/graphiql-react/src/assets/i18n/fr.json
+++ b/packages/graphiql-react/src/assets/i18n/fr.json
@@ -1,0 +1,113 @@
+{
+  "graphiql": {
+    "sidebar": {
+      "btn": {
+        "refresh_graphql_schema": "Recharger le schéma GraphQL",
+        "open_short_keys_dialog": "Ouvrir la boîte de dialogue des raccourcis clavier",
+        "open_settings_dialog": "Ouvrir la boîte de dialogue des paramètres"
+      }
+    },
+    "editor": {
+      "tools": {
+        "btn": {
+          "variables": {
+            "label": "Variables"
+          },
+          "headers": {
+            "label": "En-têtes"
+          },
+          "open_editor": {
+            "tooltip": "Afficher les outils de l'éditeur"
+          },
+          "close_editor": {
+            "tooltip": "Masquer les outils de l'éditeur"
+          }
+        }
+      }
+    },
+    "toolbar": {
+      "btn": {
+        "copy_query": {
+          "tooltip": "Copier la requête (Shift-Ctrl-C)"
+        },
+        "merge_fragment": {
+          "tooltip": "Fusionner les fragments dans la requête (Shift-Ctrl-M)"
+        },
+        "prettify_query": {
+          "tooltip": "Embellir la requête (Shift-Ctrl-P)"
+        },
+        "execute_query": {
+          "tooltip": "Exécuter la requête (Ctrl-Entrée)"
+        },
+        "stop_query": {
+          "tooltip": "Arrêter la requête (Ctrl-Entrée)"
+        }
+      }
+    }
+  },
+  "dialog": {
+    "settings": {
+      "title": "Paramètres",
+      "language": {
+        "title": "Langue",
+        "description": "Sélectionnez votre langue préférée.",
+        "btn": {
+          "language_selector": {
+            "aria_label": "Langue actuelle : Anglais (cliquez pour changer)",
+            "item_aria_label": "Sélectionner le français comme langue actuelle"
+          }
+        }
+      },
+      "persisted_headers": {
+        "title": "Conserver les en-têtes",
+        "description": "Sauvegardez les en-têtes lors du rechargement. <span class=\"graphiql-warning-text\">Activez uniquement si vous faites confiance à cet appareil.</span>",
+        "btn": {
+          "on": "Activé",
+          "off": "Désactivé"
+        }
+      },
+      "theme": {
+        "title": "Thème",
+        "description": "Ajustez l'apparence de l'interface.",
+        "btn": {
+          "system": "Système",
+          "light": "Clair",
+          "dark": "Sombre"
+        }
+      },
+      "clear_storage": {
+        "title": "Effacer le stockage",
+        "description": "Supprimez toutes les données stockées localement et recommencez à zéro.",
+        "btn": {
+          "clear_data": "Effacer les données",
+          "cleared_data": "Données effacées",
+          "error": "Échec"
+        }
+      }
+    },
+    "short_keys": {
+      "title": "Raccourcis clavier",
+      "header": {
+        "short_key": "Raccourci",
+        "function": "Fonction"
+      },
+      "function": {
+        "search_in_editor": "Rechercher dans l'éditeur",
+        "search_in_documentation": "Rechercher dans la documentation",
+        "execute_query": "Exécuter la requête",
+        "prettify_editors": "Embellir les éditeurs",
+        "merge_fragments_into_definition": "Fusionner les fragments dans la définition de l'opération",
+        "copy_query": "Copier la requête",
+        "refresh_schema": "Rafraîchir le schéma avec l'introspection"
+      },
+      "footer": "Les éditeurs utilisent les <a href=\"https://codemirror.net/5/doc/manual.html#keymaps\" target=\"_blank\" rel=\"noopener noreferrer\">mappages de touches de CodeMirror</a>, qui ajoutent davantage de raccourcis clavier. Cette instance de Graph<em>i</em>QL utilise <code>{{keyMap}}</code>."
+    }
+  },
+  "component": {
+    "add_tab": {
+      "btn": {
+        "tooltip": "Ajouter un onglet"
+      }
+    }
+  }
+}

--- a/packages/graphiql-react/src/index.ts
+++ b/packages/graphiql-react/src/index.ts
@@ -117,3 +117,4 @@ export type {
   StorageContextType,
 } from './storage';
 export type { Theme } from './theme';
+export * from './translation';

--- a/packages/graphiql-react/src/toolbar/button.tsx
+++ b/packages/graphiql-react/src/toolbar/button.tsx
@@ -1,18 +1,28 @@
-import { forwardRef, MouseEventHandler, useCallback, useState } from 'react';
+import {
+  forwardRef,
+  MouseEventHandler,
+  useCallback,
+  useContext,
+  useState,
+} from 'react';
 import { clsx } from 'clsx';
 import { Tooltip, UnStyledButton } from '../ui';
 
 import './button.css';
+import { TranslationContext } from '../translation';
 
 type ToolbarButtonProps = {
-  label: string;
+  label?: string;
+  labelKey?: string;
 };
 
 export const ToolbarButton = forwardRef<
   HTMLButtonElement,
   ToolbarButtonProps & JSX.IntrinsicElements['button']
->(({ label, onClick, ...props }, ref) => {
+>(({ label, onClick, labelKey, ...props }, ref) => {
   const [error, setError] = useState<Error | null>(null);
+  const { currentLanguage, translationService } =
+    useContext(TranslationContext);
   const handleClick: MouseEventHandler<HTMLButtonElement> = useCallback(
     event => {
       try {
@@ -29,8 +39,12 @@ export const ToolbarButton = forwardRef<
     [onClick],
   );
 
+  const translatedLabel =
+    label ||
+    (labelKey ? translationService.translate(labelKey, currentLanguage) : '');
+
   return (
-    <Tooltip label={label}>
+    <Tooltip label={translatedLabel}>
       <UnStyledButton
         {...props}
         ref={ref}
@@ -41,7 +55,7 @@ export const ToolbarButton = forwardRef<
           props.className,
         )}
         onClick={handleClick}
-        aria-label={error ? error.message : label}
+        aria-label={error ? error.message : translatedLabel}
         aria-invalid={error ? 'true' : props['aria-invalid']}
       />
     </Tooltip>

--- a/packages/graphiql-react/src/toolbar/execute.tsx
+++ b/packages/graphiql-react/src/toolbar/execute.tsx
@@ -4,6 +4,8 @@ import { PlayIcon, StopIcon } from '../icons';
 import { DropdownMenu, Tooltip } from '../ui';
 
 import './execute.css';
+import { useContext } from 'react';
+import { TranslationContext } from '../translation';
 
 export function ExecuteButton() {
   const { queryEditor, setOperationName } = useEditorContext({
@@ -16,11 +18,20 @@ export function ExecuteButton() {
       caller: ExecuteButton,
     });
 
+  const { currentLanguage, translationService } =
+    useContext(TranslationContext);
+
   const operations = queryEditor?.operations || [];
   const hasOptions = operations.length > 1 && typeof operationName !== 'string';
   const isRunning = isFetching || isSubscribed;
 
-  const label = `${isRunning ? 'Stop' : 'Execute'} query (Ctrl-Enter)`;
+  const buttonTranslationKey = isRunning
+    ? 'graphiql.toolbar.btn.stop_query.tooltip'
+    : 'graphiql.toolbar.btn.execute_query.tooltip';
+  const label = translationService.translate(
+    buttonTranslationKey,
+    currentLanguage,
+  );
   const buttonProps = {
     type: 'button' as const,
     className: 'graphiql-execute-button',

--- a/packages/graphiql-react/src/translation/components/language-selector/language-selector.css
+++ b/packages/graphiql-react/src/translation/components/language-selector/language-selector.css
@@ -1,0 +1,12 @@
+.language-selector-content {
+  z-index: 10;
+  overflow-y: auto;
+  max-height: 200px;
+}
+
+.language-selector .graphiql-chevron-icon {
+  color: hsla(var(--color-neutral), var(--alpha-tertiary));
+  height: var(--px-12);
+  margin-left: var(--px-2);
+  width: var(--px-12);
+}

--- a/packages/graphiql-react/src/translation/components/language-selector/language-selector.tsx
+++ b/packages/graphiql-react/src/translation/components/language-selector/language-selector.tsx
@@ -1,0 +1,62 @@
+import { useContext, useState } from 'react';
+import { TranslationContext } from '../../translation-context';
+import { DropdownMenu } from '../../../ui';
+import { ChevronDownIcon, ChevronUpIcon } from '../../../icons';
+import './language-selector.css';
+
+/**
+ * LanguageSelector Component
+ *
+ * A dropdown menu component that allows users to select a language from the supported languages.
+ *
+ * @returns {JSX.Element} A dropdown menu for selecting a language.
+ */
+export const LanguageSelector = () => {
+  const {
+    currentLanguage,
+    setCurrentLanguage,
+    supportedLanguages,
+    translationService,
+  } = useContext(TranslationContext);
+  const [isOpen, setOpen] = useState(false);
+
+  const buttonProps = {
+    type: 'button' as const,
+    className: 'language-selector graphiql-button',
+    children: isOpen ? (
+      <ChevronUpIcon className="graphiql-chevron-icon" aria-hidden="true" />
+    ) : (
+      <ChevronDownIcon className="graphiql-chevron-icon" aria-hidden="true" />
+    ),
+    'aria-label': translationService.translate(
+      'dialog.settings.language.btn.language_selector.aria_label',
+      currentLanguage,
+    ),
+  };
+
+  return (
+    <DropdownMenu onOpenChange={() => setOpen(isOpen)}>
+      <DropdownMenu.Button
+        {...buttonProps}
+        className="language-selector graphiql-button"
+      >
+        {currentLanguage.toUpperCase()}
+      </DropdownMenu.Button>
+
+      <DropdownMenu.Content align="end" className="language-selector-content">
+        {supportedLanguages.map(language => (
+          <DropdownMenu.Item
+            key={language}
+            onSelect={() => setCurrentLanguage(language)}
+            aria-label={translationService.translate(
+              'dialog.settings.language.btn.language_selector.item_aria_label',
+              language,
+            )}
+          >
+            {language}
+          </DropdownMenu.Item>
+        ))}
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  );
+};

--- a/packages/graphiql-react/src/translation/components/translated-text/translated-text.tsx
+++ b/packages/graphiql-react/src/translation/components/translated-text/translated-text.tsx
@@ -1,0 +1,30 @@
+import { useContext } from 'react';
+import { TranslationContext } from '../../translation-context';
+import { TranslateTextProps } from '../../models/translate-text-props';
+
+/**
+ * TranslateText Component
+ *
+ * This component is responsible for translating a given text key using the translation service provided by the TranslationContext.
+ *
+ * @param {TranslateTextProps} props - Component properties.
+ *
+ * @returns {JSX.Element} A translated text.
+ */
+export const TranslateText = ({
+  translationKey,
+  translationParams,
+}: TranslateTextProps) => {
+  const { currentLanguage, translationService } =
+    useContext(TranslationContext);
+  const translation = translationService.translate(
+    translationKey,
+    currentLanguage,
+    translationParams,
+  );
+  return translation ? (
+    <span dangerouslySetInnerHTML={{ __html: translation }} />
+  ) : (
+    <>translationKey</>
+  );
+};

--- a/packages/graphiql-react/src/translation/index.ts
+++ b/packages/graphiql-react/src/translation/index.ts
@@ -1,0 +1,4 @@
+export * from './components/language-selector/language-selector';
+export * from './translation-context';
+export * from './translation-provider';
+export * from './components/translated-text/translated-text';

--- a/packages/graphiql-react/src/translation/models/translate-text-props.ts
+++ b/packages/graphiql-react/src/translation/models/translate-text-props.ts
@@ -1,0 +1,15 @@
+/**
+ * Interface defining the properties for the {@link TranslateText} component.
+ *
+ */
+export interface TranslateTextProps {
+  /**
+   * The key for the text to be translated.
+   */
+  translationKey: string;
+
+  /**
+   * Optional parameters for dynamic translation values.
+   */
+  translationParams?: Record<string, string>;
+}

--- a/packages/graphiql-react/src/translation/models/translation-bundle.ts
+++ b/packages/graphiql-react/src/translation/models/translation-bundle.ts
@@ -1,0 +1,90 @@
+import { Translation } from './translations';
+
+/**
+ * Class representing a bundle of translations.
+ */
+export class TranslationBundle {
+  /**
+   * Stores the flattened translation key-value pairs.
+   *
+   * Example:
+   * {
+   *   "graphiql.editor.btn.headers.label": "Headers"
+   * }
+   */
+  translationBundle: Record<string, string>;
+
+  /**
+   * Creates a new TranslationBundle instance.
+   * @param {Record<string, string | Translation>} translationBundle - The initial translation bundle.
+   */
+  constructor(translationBundle: Record<string, string | Translation>) {
+    this.translationBundle = this.flattenObject(translationBundle);
+  }
+
+  /**
+   * Retrieves a translation string by key.
+   *
+   * @param {string} key - The translation key.
+   * @returns {string | undefined} The translated string, or undefined if the key is not found.
+   */
+  getTranslation(key: string): string | undefined {
+    return this.translationBundle[key];
+  }
+
+  /**
+   * Merges a new translation bundle into the existing one.
+   *
+   * @param {Record<string, string | Translation>} translationBundle - The translation bundle to merge.
+   */
+  merge(translationBundle: Record<string, string | Translation>) {
+    this.translationBundle = {
+      ...this.translationBundle,
+      ...this.flattenObject(translationBundle),
+    };
+  }
+
+  /**
+   * Flattens a nested translation object into a key-value map.
+   *
+   * @param {any} obj - The object to flatten.
+   * @param {string} [prefix=''] - The prefix for nested keys.
+   * @returns {Record<string, string>} The flattened object.
+   *
+   * @example
+   * If the <code>obj</code> is:
+   * ```json
+   * {
+   *   "editor": {
+   *     "btn": {
+   *       "headers": {
+   *         "label": "Headers"
+   *       }
+   *     }
+   *   }
+   * }
+   * ```
+   * then the result is:
+   * ```json
+   * {
+   *   "editor.btn.headers.label": "Headers"
+   * }
+   * ```
+   */
+  private flattenObject(obj: any, prefix = ''): Record<string, string> {
+    const result: Record<string, string> = {};
+    for (const key in obj) {
+      const newKey = prefix ? `${prefix}.${key}` : key;
+      if (
+        typeof obj[key] === 'object' &&
+        obj[key] !== null &&
+        !Array.isArray(obj[key])
+      ) {
+        Object.assign(result, this.flattenObject(obj[key], newKey));
+      } else {
+        result[newKey] = obj[key] as string;
+      }
+    }
+    return result;
+  }
+}

--- a/packages/graphiql-react/src/translation/models/translation-context-type.ts
+++ b/packages/graphiql-react/src/translation/models/translation-context-type.ts
@@ -1,0 +1,31 @@
+import { TranslationService } from '../services/translation-service';
+
+/**
+ * Type definition for the {@link TranslationContext}, which holds all related language data.
+ */
+export type TranslationContextType = {
+  /**
+   * The currently selected language.
+   */
+  currentLanguage: string;
+
+  /**
+   * An array of all supported languages.
+   */
+  supportedLanguages: string[];
+
+  /**
+   * Sets the currently selected language.
+   */
+  setCurrentLanguage: (language: string) => void;
+
+  /**
+   * Sets the list of all supported languages.
+   */
+  setSupportedLanguages: (languages: string[]) => void;
+
+  /**
+   * The translation service used for text translations.
+   */
+  translationService: TranslationService;
+};

--- a/packages/graphiql-react/src/translation/models/translations.ts
+++ b/packages/graphiql-react/src/translation/models/translations.ts
@@ -1,0 +1,43 @@
+/**
+ * Represents a flat key-value pair translation structure.
+ * The keys can either be dot-separated paths or nested objects.
+ *
+ * @example
+ * ```typescript
+ * const translation: Translation = {
+ *   "editor.title": "Editor",
+ *   "editor": {
+ *     "description": "This is the editor"
+ *   }
+ * };
+ * ```
+ */
+export interface Translation {
+  [key: string]: string | Translation;
+}
+
+/**
+ * Represents a collection of translations for multiple languages,
+ * using a flat structure with dot-separated keys or nested objects.
+ *
+ * @example
+ * ```typescript
+ * const translations: Translations = {
+ *   en: {
+ *     "editor.title": "Editor",
+ *     "editor": {
+ *       "description": "This is the editor"
+ *     }
+ *   },
+ *   fr: {
+ *     "editor.title": "Éditeur",
+ *     "editor": {
+ *       "description": "C'est l'éditeur"
+ *     }
+ *   }
+ * };
+ * ```
+ */
+export interface Translations {
+  [language: string]: Translation;
+}

--- a/packages/graphiql-react/src/translation/services/translation-service.ts
+++ b/packages/graphiql-react/src/translation/services/translation-service.ts
@@ -1,0 +1,134 @@
+import { TranslationBundle } from '../models/translation-bundle';
+
+/**
+ * Service for managing translations across multiple languages.
+ */
+export class TranslationService {
+  /**
+   * Stores translation bundles for different languages.
+   */
+  private readonly translationBundles: Record<string, TranslationBundle> = {};
+
+  /**
+   * The default language used as a fallback when a translation is not found.
+   */
+  private readonly defaultLanguage: string;
+
+  /**
+   * Initializes the translation service with predefined translation bundles.
+   *
+   * @param {Record<string, TranslationBundle>} [translationBundles={}] - A record of language codes mapped to their respective translation bundles.
+   * @param {string} [defaultLanguage='en'] - The default language to use when a translation is missing.
+   *
+   * @example
+   * ```typescript
+   * const service = new TranslationService({
+   *   en: new TranslationBundle({ "plugin.btn.show_plugin": "Show {{pluginTitle}}" }),
+   *   fr: new TranslationBundle({ "plugin.btn.show_plugin": "Afficher {{pluginTitle}}" })
+   * }, 'en');
+   * ```
+   */
+  constructor(
+    translationBundles: Record<string, TranslationBundle> = {},
+    defaultLanguage = 'en',
+  ) {
+    this.translationBundles = translationBundles;
+    this.defaultLanguage = defaultLanguage;
+  }
+
+  /**
+   * Retrieves the translated text for a given key in the specified language.
+   * Falls back to the default language if the key is not found in the selected language.
+   *
+   * @param {string} key - The translation key.
+   * @param {string} language - The language code (e.g., "en", "fr").
+   * @param {Record<string, string>} [params={}] - Optional parameters to replace placeholders in the translation.
+   * @returns {string} The translated string, or the key itself if no translation is found.
+   *
+   * @example
+   * ```typescript
+   * const service = new TranslationService({
+   *   en: new TranslationBundle({ "plugin.btn.show_plugin": "Show {{pluginTitle}}" }),
+   *   fr: new TranslationBundle({ "plugin.btn.show_plugin": "Afficher {{pluginTitle}}" })
+   * }, 'en');
+   *
+   * service.translate("plugin.btn.show_plugin", "fr", { pluginTitle: "GraphiQL Explorer" });
+   * // Returns: "Afficher GraphiQL Explorer"
+   *
+   * service.translate("plugin.btn.unknown_key", "fr");
+   * // Falls back to English, returns: "plugin.btn.unknown_key"
+   * ```
+   */
+  translate(
+    key: string,
+    language: string,
+    params: Record<string, string> = {},
+  ): string {
+    const translationBundle = this.translationBundles[language];
+    let translation = undefined;
+
+    if (translationBundle) {
+      translation = translationBundle.getTranslation(key);
+    }
+
+    // Fallback to the default language if translation not found
+    translation ||=
+      this.translationBundles[this.defaultLanguage]?.getTranslation(key);
+
+    return translation ? this.applyParameters(translation, params) : key;
+  }
+
+  /**
+   * Replaces placeholders in a translation string with actual parameter values.
+   *
+   * @param {string} translation - The translation string with placeholders (e.g., "Show {{pluginTitle}}").
+   * @param {Record<string, string>} [parameters={}] - The key-value pairs for replacing placeholders.
+   * @returns {string} The translation with placeholders replaced.
+   *
+   * @example
+   * ```typescript
+   * const service = new TranslationService({
+   *   en: new TranslationBundle({ "plugin.btn.show_plugin": "Show {{pluginTitle}}" })
+   * }, 'en');
+   *
+   * service.translate("plugin.btn.show_plugin", "en", { pluginTitle: "GraphiQL Explorer" });
+   * // Returns: "Show GraphiQL Explorer"
+   * ```
+   */
+  private applyParameters(
+    translation: string,
+    parameters: Record<string, string> = {},
+  ): string {
+    if (!parameters || Object.keys(parameters).length === 0) {
+      return translation;
+    }
+
+    let filledTranslation = translation;
+    for (const key in parameters) {
+      filledTranslation = filledTranslation.replaceAll(
+        `{{${key}}}`,
+        parameters[key],
+      );
+    }
+    return filledTranslation;
+  }
+
+  /**
+   * Retrieves the list of supported language codes.
+   *
+   * @returns {string[]} An array of supported language codes.
+   *
+   * @example
+   * ```typescript
+   * const service = new TranslationService({
+   *   en: new TranslationBundle({ "plugin.btn.show_plugin": "Show {{pluginTitle}}" }),
+   *   fr: new TranslationBundle({ "plugin.btn.show_plugin": "Afficher {{pluginTitle}}" })
+   * }, 'en');
+   *
+   * service.getSupportedLanguages(); // Returns: ["en", "fr"]
+   * ```
+   */
+  getSupportedLanguages(): string[] {
+    return Object.keys(this.translationBundles);
+  }
+}

--- a/packages/graphiql-react/src/translation/translation-context.ts
+++ b/packages/graphiql-react/src/translation/translation-context.ts
@@ -1,0 +1,14 @@
+import { createContext } from 'react';
+import { TranslationContextType } from './models/translation-context-type';
+import { TranslationService } from './services/translation-service';
+
+/**
+ * A context that stores all translation-related properties.
+ */
+export const TranslationContext = createContext<TranslationContextType>({
+  currentLanguage: 'en',
+  supportedLanguages: [],
+  setCurrentLanguage() {},
+  setSupportedLanguages() {},
+  translationService: new TranslationService(),
+});

--- a/packages/graphiql-react/src/translation/translation-provider.tsx
+++ b/packages/graphiql-react/src/translation/translation-provider.tsx
@@ -1,0 +1,116 @@
+import React, { useState, useEffect } from 'react';
+import { TranslationService } from './services/translation-service';
+import { TranslationContext } from './translation-context';
+
+import en from '../assets/i18n/en.json';
+import fr from '../assets/i18n/fr.json';
+import { TranslationBundle } from './models/translation-bundle';
+import { Translations } from './models/translations';
+
+/**
+ * TranslationProvider component is responsible for managing the translation state and providing the translation service
+ * to the application through context.
+ *
+ * It provides the following context values:
+ * - `currentLanguage`: The language currently selected.
+ * - `supportedLanguages`: An array of supported languages.
+ * - `setCurrentLanguage`: A function to set the current language.
+ * - `setSupportedLanguages`: A function to update supported languages.
+ * - `translationService`: An instance of `TranslationService` for translating strings.
+ *
+ * @param {Object} props - Component props.
+ * @param {Translations} [props.translations] - Optional external translation bundles to merge with the internal ones.
+ * @param {string} [props.selectedLanguage] - The initially selected language, defaults to 'en'.
+ *
+ * @example
+ * ```typescript
+ * <TranslationProvider selectedLanguage="fr" translations={translations}>
+ *   <App />
+ * </TranslationProvider>
+ * ```
+ */
+export const TranslationProvider = (props: any) => {
+  const translationService = new TranslationService(
+    getTranslationBundles(props.translations),
+  );
+
+  const allSupportedLanguages = translationService.getSupportedLanguages();
+  const selectedLanguage = allSupportedLanguages.find(
+    language => language === props.selectedLanguage,
+  );
+
+  const [currentLanguage, setCurrentLanguage] = useState<string>(
+    selectedLanguage || 'en',
+  );
+  const [supportedLanguages, setSupportedLanguages] = useState<string[]>(
+    allSupportedLanguages,
+  );
+
+  useEffect(() => {
+    if (selectedLanguage && selectedLanguage !== currentLanguage) {
+      setCurrentLanguage(selectedLanguage);
+    }
+  }, [selectedLanguage]);
+
+  return (
+    <TranslationContext.Provider
+      value={{
+        currentLanguage,
+        supportedLanguages,
+        setCurrentLanguage,
+        setSupportedLanguages,
+        translationService,
+      }}
+    >
+      {props.children}
+    </TranslationContext.Provider>
+  );
+};
+
+/**
+ * Merges external translations with internal translation bundles. This function takes the translations object and merges them with internal
+ * translation bundles (like `en` and `fr`).
+ *
+ * @param {Translations} translations - An object containing translations for different languages.
+ * @returns {Record<string, TranslationBundle>} A record of language codes mapped to their translation bundles.
+ *
+ * @example
+ * ```typescript
+ * const translations = {
+ *   en: { "editor.title": "Editor" },
+ *   fr: { "editor.title": "Éditeur" },
+ * };
+ * getTranslationBundles(translations);
+ * ```
+ */
+const getTranslationBundles = (translations: Translations) => {
+  const translationBundles: Record<string, TranslationBundle> =
+    getInternalTranslationBundles();
+  if (!translations) {
+    return translationBundles;
+  }
+  for (const language of Object.keys(translations)) {
+    const internalTranslationBundle = translationBundles[language];
+    const translationConfiguration = translations[language];
+    if (internalTranslationBundle) {
+      internalTranslationBundle.merge(translationConfiguration);
+    } else {
+      translationBundles[language] = new TranslationBundle(
+        translationConfiguration,
+      );
+    }
+  }
+  return translationBundles;
+};
+
+/**
+ * Initializes the internal translation bundles with the default language translations. This includes the `en` (English) and `fr` (French) translations.
+ *
+ * @returns {Record<string, TranslationBundle>} A record of language codes mapped to their translation bundles.
+ */
+const getInternalTranslationBundles = (): Record<string, TranslationBundle> => {
+  const translationBundles: Record<string, TranslationBundle> = {};
+  translationBundles.en = new TranslationBundle(en);
+  translationBundles.fr = new TranslationBundle(fr);
+  return translationBundles;
+};

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -16,6 +16,7 @@ import React, {
   useState,
   useEffect,
   useMemo,
+  useContext,
 } from 'react';
 
 import {
@@ -61,6 +62,10 @@ import {
   VariableEditor,
   WriteableEditorProps,
   isMacOs,
+  TranslationProvider,
+  TranslateText,
+  LanguageSelector,
+  TranslationContext,
 } from '@graphiql/react';
 
 const majorVersion = parseInt(React.version.slice(0, 2), 10);
@@ -169,13 +174,15 @@ export function GraphiQL({
       validationRules={validationRules}
       variables={variables}
     >
-      <GraphiQLInterface
-        confirmCloseTab={confirmCloseTab}
-        showPersistHeadersSettings={shouldPersistHeaders !== false}
-        disableTabs={props.disableTabs ?? false}
-        forcedTheme={props.forcedTheme}
-        {...props}
-      />
+      <TranslationProvider {...props}>
+        <GraphiQLInterface
+          confirmCloseTab={confirmCloseTab}
+          showPersistHeadersSettings={shouldPersistHeaders !== false}
+          disableTabs={props.disableTabs ?? false}
+          forcedTheme={props.forcedTheme}
+          {...props}
+        />
+      </TranslationProvider>
     </GraphiQLProvider>
   );
 }
@@ -265,6 +272,8 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
   const copy = useCopyQuery({ onCopyQuery: props.onCopyQuery });
   const merge = useMergeQuery();
   const prettify = usePrettifyEditors();
+  const { currentLanguage, translationService } =
+    useContext(TranslationContext);
 
   const { theme, setTheme } = useTheme(props.defaultTheme);
 
@@ -349,16 +358,22 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
     isChildComponentType(child, GraphiQL.Toolbar),
   ) || (
     <>
-      <ToolbarButton onClick={prettify} label="Prettify query (Shift-Ctrl-P)">
+      <ToolbarButton
+        onClick={prettify}
+        labelKey="graphiql.toolbar.btn.prettify_query.tooltip"
+      >
         <PrettifyIcon className="graphiql-toolbar-icon" aria-hidden="true" />
       </ToolbarButton>
       <ToolbarButton
         onClick={merge}
-        label="Merge fragments into query (Shift-Ctrl-M)"
+        labelKey="graphiql.toolbar.btn.merge_fragment.tooltip"
       >
         <MergeIcon className="graphiql-toolbar-icon" aria-hidden="true" />
       </ToolbarButton>
-      <ToolbarButton onClick={copy} label="Copy query (Shift-Ctrl-C)">
+      <ToolbarButton
+        onClick={copy}
+        labelKey="graphiql.toolbar.btn.copy_query.tooltip"
+      >
         <CopyIcon className="graphiql-toolbar-icon" aria-hidden="true" />
       </ToolbarButton>
       {props.toolbar?.additionalContent}
@@ -470,13 +485,17 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
     }
   }, []);
 
+  const addTabLabel = translationService.translate(
+    'component.add_tab.btn.tooltip',
+    currentLanguage,
+  );
   const addTab = (
-    <Tooltip label="Add tab">
+    <Tooltip label={addTabLabel}>
       <UnStyledButton
         type="button"
         className="graphiql-tab-add"
         onClick={handleAddTab}
-        aria-label="Add tab"
+        aria-label={addTabLabel}
       >
         <PlusIcon aria-hidden="true" />
       </UnStyledButton>
@@ -554,12 +573,19 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
             })}
           </div>
           <div className="graphiql-sidebar-section">
-            <Tooltip label="Re-fetch GraphQL schema">
+            <Tooltip
+              label={
+                <TranslateText translationKey="graphiql.sidebar.btn.refresh_graphql_schema" />
+              }
+            >
               <UnStyledButton
                 type="button"
                 disabled={schemaContext.isFetching}
                 onClick={handleRefetchSchema}
-                aria-label="Re-fetch GraphQL schema"
+                aria-label={translationService.translate(
+                  'graphiql.sidebar.btn.refresh_graphql_schema',
+                  currentLanguage,
+                )}
               >
                 <ReloadIcon
                   className={schemaContext.isFetching ? 'graphiql-spin' : ''}
@@ -567,22 +593,36 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
                 />
               </UnStyledButton>
             </Tooltip>
-            <Tooltip label="Open short keys dialog">
+            <Tooltip
+              label={
+                <TranslateText translationKey="graphiql.sidebar.btn.open_short_keys_dialog" />
+              }
+            >
               <UnStyledButton
                 type="button"
                 data-value="short-keys"
                 onClick={handleShowDialog}
-                aria-label="Open short keys dialog"
+                aria-label={translationService.translate(
+                  'graphiql.sidebar.btn.open_short_keys_dialog',
+                  currentLanguage,
+                )}
               >
                 <KeyboardShortcutIcon aria-hidden="true" />
               </UnStyledButton>
             </Tooltip>
-            <Tooltip label="Open settings dialog">
+            <Tooltip
+              label={
+                <TranslateText translationKey="graphiql.sidebar.btn.open_settings_dialog" />
+              }
+            >
               <UnStyledButton
                 type="button"
                 data-value="settings"
                 onClick={handleShowDialog}
-                aria-label="Open settings dialog"
+                aria-label={translationService.translate(
+                  'graphiql.sidebar.btn.open_settings_dialog',
+                  currentLanguage,
+                )}
               >
                 <SettingsIcon aria-hidden="true" />
               </UnStyledButton>
@@ -693,7 +733,7 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
                         onClick={handleToolsTabClick}
                         data-name="variables"
                       >
-                        Variables
+                        <TranslateText translationKey="graphiql.editor.tools.btn.variables.label" />
                       </UnStyledButton>
                       {isHeadersEditorEnabled && (
                         <UnStyledButton
@@ -707,15 +747,17 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
                           onClick={handleToolsTabClick}
                           data-name="headers"
                         >
-                          Headers
+                          <TranslateText translationKey="graphiql.editor.tools.btn.headers.label" />
                         </UnStyledButton>
                       )}
 
                       <Tooltip
                         label={
-                          editorToolsResize.hiddenElement === 'second'
-                            ? 'Show editor tools'
-                            : 'Hide editor tools'
+                          editorToolsResize.hiddenElement === 'second' ? (
+                            <TranslateText translationKey="graphiql.editor.tools.btn.open_editor.tooltip" />
+                          ) : (
+                            <TranslateText translationKey="graphiql.editor.tools.btn.close_editor.tooltip" />
+                          )
                         }
                       >
                         <UnStyledButton
@@ -800,7 +842,7 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
         >
           <div className="graphiql-dialog-header">
             <Dialog.Title className="graphiql-dialog-title">
-              Short Keys
+              <TranslateText translationKey="dialog.short_keys.title" />
             </Dialog.Title>
             <Dialog.Close />
           </div>
@@ -814,21 +856,30 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
         >
           <div className="graphiql-dialog-header">
             <Dialog.Title className="graphiql-dialog-title">
-              Settings
+              <TranslateText translationKey="dialog.settings.title" />
             </Dialog.Title>
             <Dialog.Close />
           </div>
+          <div className="graphiql-dialog-section">
+            <div>
+              <div className="graphiql-dialog-section-title">
+                <TranslateText translationKey="dialog.settings.language.title" />
+              </div>
+              <div className="graphiql-dialog-section-caption">
+                <TranslateText translationKey="dialog.settings.language.description" />
+              </div>
+            </div>
+            <LanguageSelector />
+          </div>
+
           {props.showPersistHeadersSettings ? (
             <div className="graphiql-dialog-section">
               <div>
                 <div className="graphiql-dialog-section-title">
-                  Persist headers
+                  <TranslateText translationKey="dialog.settings.persisted_headers.title" />
                 </div>
                 <div className="graphiql-dialog-section-caption">
-                  Save headers upon reloading.{' '}
-                  <span className="graphiql-warning-text">
-                    Only enable if you trust this device.
-                  </span>
+                  <TranslateText translationKey="dialog.settings.persisted_headers.description" />
                 </div>
               </div>
               <ButtonGroup>
@@ -839,7 +890,7 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
                   data-value="true"
                   onClick={handlePersistHeaders}
                 >
-                  On
+                  <TranslateText translationKey="dialog.settings.persisted_headers.btn.on" />
                 </Button>
                 <Button
                   type="button"
@@ -847,7 +898,7 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
                   className={editorContext.shouldPersistHeaders ? '' : 'active'}
                   onClick={handlePersistHeaders}
                 >
-                  Off
+                  <TranslateText translationKey="dialog.settings.persisted_headers.btn.off" />
                 </Button>
               </ButtonGroup>
             </div>
@@ -855,9 +906,11 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
           {!forcedTheme && (
             <div className="graphiql-dialog-section">
               <div>
-                <div className="graphiql-dialog-section-title">Theme</div>
+                <div className="graphiql-dialog-section-title">
+                  <TranslateText translationKey="dialog.settings.theme.title" />
+                </div>
                 <div className="graphiql-dialog-section-caption">
-                  Adjust how the interface appears.
+                  <TranslateText translationKey="dialog.settings.theme.description" />
                 </div>
               </div>
               <ButtonGroup>
@@ -866,7 +919,7 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
                   className={theme === null ? 'active' : ''}
                   onClick={handleChangeTheme}
                 >
-                  System
+                  <TranslateText translationKey="dialog.settings.theme.btn.system" />
                 </Button>
                 <Button
                   type="button"
@@ -874,7 +927,7 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
                   data-theme="light"
                   onClick={handleChangeTheme}
                 >
-                  Light
+                  <TranslateText translationKey="dialog.settings.theme.btn.light" />
                 </Button>
                 <Button
                   type="button"
@@ -882,7 +935,7 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
                   data-theme="dark"
                   onClick={handleChangeTheme}
                 >
-                  Dark
+                  <TranslateText translationKey="dialog.settings.theme.btn.dark" />
                 </Button>
               </ButtonGroup>
             </div>
@@ -891,10 +944,10 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
             <div className="graphiql-dialog-section">
               <div>
                 <div className="graphiql-dialog-section-title">
-                  Clear storage
+                  <TranslateText translationKey="dialog.settings.clear_storage.title" />
                 </div>
                 <div className="graphiql-dialog-section-caption">
-                  Remove all locally stored data and start fresh.
+                  <TranslateText translationKey="dialog.settings.clear_storage.description" />
                 </div>
               </div>
               <Button
@@ -904,9 +957,15 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
                 onClick={handleClearData}
               >
                 {{
-                  success: 'Cleared data',
-                  error: 'Failed',
-                }[clearStorageStatus!] || 'Clear data'}
+                  success: (
+                    <TranslateText translationKey="dialog.settings.clear_storage.btn.cleared_data" />
+                  ),
+                  error: (
+                    <TranslateText translationKey="dialog.settings.clear_storage.btn.error" />
+                  ),
+                }[clearStorageStatus!] || (
+                  <TranslateText translationKey="dialog.settings.clear_storage.btn.clear_data" />
+                )}
               </Button>
             </div>
           ) : null}
@@ -919,17 +978,17 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
 const modifier = isMacOs ? '⌘' : 'Ctrl';
 
 const SHORT_KEYS = Object.entries({
-  'Search in editor': [modifier, 'F'],
-  'Search in documentation': [modifier, 'K'],
-  'Execute query': [modifier, 'Enter'],
-  'Prettify editors': ['Ctrl', 'Shift', 'P'],
-  'Merge fragments definitions into operation definition': [
+  'dialog.short_keys.function.search_in_editor': [modifier, 'F'],
+  'dialog.short_keys.function.search_in_documentation': [modifier, 'K'],
+  'dialog.short_keys.function.execute_query': [modifier, 'Enter'],
+  'dialog.short_keys.function.prettify_editors': ['Ctrl', 'Shift', 'P'],
+  'dialog.short_keys.function.merge_fragments_into_definition': [
     'Ctrl',
     'Shift',
     'M',
   ],
-  'Copy query': ['Ctrl', 'Shift', 'C'],
-  'Re-fetch schema using introspection': ['Ctrl', 'Shift', 'R'],
+  'dialog.short_keys.function.copy_query': ['Ctrl', 'Shift', 'C'],
+  'dialog.short_keys.function.refresh_schema': ['Ctrl', 'Shift', 'R'],
 });
 
 function ShortKeys({ keyMap }: { keyMap: string }): ReactElement {
@@ -938,8 +997,12 @@ function ShortKeys({ keyMap }: { keyMap: string }): ReactElement {
       <table className="graphiql-table">
         <thead>
           <tr>
-            <th>Short Key</th>
-            <th>Function</th>
+            <th>
+              <TranslateText translationKey="dialog.short_keys.header.short_key" />
+            </th>
+            <th>
+              <TranslateText translationKey="dialog.short_keys.header.function" />
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -953,22 +1016,18 @@ function ShortKeys({ keyMap }: { keyMap: string }): ReactElement {
                   </Fragment>
                 ))}
               </td>
-              <td>{title}</td>
+              <td>
+                <TranslateText translationKey={title} />
+              </td>
             </tr>
           ))}
         </tbody>
       </table>
       <p>
-        The editors use{' '}
-        <a
-          href="https://codemirror.net/5/doc/manual.html#keymaps"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          CodeMirror Key Maps
-        </a>{' '}
-        that add more short keys. This instance of Graph<em>i</em>QL uses{' '}
-        <code>{keyMap}</code>.
+        <TranslateText
+          translationKey="dialog.short_keys.footer"
+          translationParams={{ keyMap }}
+        />
       </p>
     </div>
   );

--- a/resources/custom-words.txt
+++ b/resources/custom-words.txt
@@ -231,3 +231,6 @@ zdravo
 أهلاً
 سلام
 हेलो
+Éditeur
+l'éditeur
+Afficher


### PR DESCRIPTION
## What
Added core internationalization functionality.

## Why
We need this functionality for the Workbench.

## How
- Implemented a translation service responsible for translating labels into different languages;
- Implemented a translation context component;
- Implemented the TranslatedText component, responsible for translating a given text key using the translation service provided by TranslationContext. When the translation context changes, TranslatedText will re-render with the translations for the selected language;
- Implemented the LanguageSelector component, allowing users to select a language from the supported options.

The translation functionality includes built-in language bundles for English ("en") and French ("fr"). When the translation context is created, it can receive external translation configurations, which are merged with the internal ones. If duplicates exist, external translations override the internal ones.

### Configuration
The GraphiQL component was extended with the following configuration to manage translation functionality:
 - selectedLanguage – Specifies the current language used for translation, e.g., "en", "fr". If not provided, "en" is used by default.
 - languages – An array describing supported languages for the language dropdown menu. Each object in the array should have the following structure:
  ``` json 
     { 
          "code": "fr", 
          "label": "Français" 
     } 
```
  - code: The language code.
  - label: The display name used in the LanguageSelector dropdown.
 - translations – An object containing additional language bundles. Example: 
 ``` json 
     { 
         "translations": { 
           "fr": {
                "graphiql": {
                         "sidebar": { 
                                "btn": { 
                                     "refresh_graphql_schema": "Recharger le schéma GraphQL"
                                       ... 
              }, 
            "en": { 
                   "graphiql": { 
                            "sidebar": { 
                                   "btn": { 
                                       "refresh_graphql_schema": "Re-fetch GraphQL schema" 
                                          ... 
}
 ```