### PR TITLE
GDB-11239: Translate graphiql sidebar plugin buttons

### DIFF
--- a/packages/graphiql-plugin-code-exporter/src/index.tsx
+++ b/packages/graphiql-plugin-code-exporter/src/index.tsx
@@ -24,6 +24,7 @@ export function codeExporterPlugin(
   props: GraphiQLCodeExporterPluginProps,
 ): GraphiQLPlugin {
   return {
+    id: 'graphiql-plugin-code-exporter',
     title: 'GraphiQL Code Exporter',
     icon: () => (
       <svg

--- a/packages/graphiql-plugin-explorer/src/index.tsx
+++ b/packages/graphiql-plugin-explorer/src/index.tsx
@@ -108,6 +108,7 @@ export function explorerPlugin(
   props?: GraphiQLExplorerPluginProps,
 ): GraphiQLPlugin {
   return {
+    id: 'graphiql_explorer',
     title: 'GraphiQL Explorer',
     icon: FolderPlusIcon,
     content: () => <ExplorerPlugin {...props} />,

--- a/packages/graphiql-react/src/assets/i18n/en.json
+++ b/packages/graphiql-react/src/assets/i18n/en.json
@@ -109,5 +109,23 @@
         "tooltip": "Add tab"
       }
     }
+  },
+  "plugin": {
+    "history": {
+      "title": "History"
+    },
+    "documentation_explorer": {
+      "title": "Documentation Explorer"
+    },
+    "graphiql_explorer": {
+      "title": "GraphiQL Explorer"
+    },
+    "graphiql-plugin-code-exporter": {
+      "title": "GraphiQL Code Exporter"
+    },
+    "btn": {
+      "show_plugin": "Show {{pluginTitle}}",
+      "hide_plugin": "Hide {{pluginTitle}}"
+    }
   }
 }

--- a/packages/graphiql-react/src/assets/i18n/fr.json
+++ b/packages/graphiql-react/src/assets/i18n/fr.json
@@ -109,5 +109,23 @@
         "tooltip": "Ajouter un onglet"
       }
     }
+  },
+  "plugin": {
+    "history": {
+      "title": "Historique"
+    },
+    "documentation_explorer": {
+      "title": "Explorateur de documentation"
+    },
+    "graphiql_explorer": {
+      "title": "Explorateur GraphiQL"
+    },
+    "graphiql-plugin-code-exporter": {
+      "title": "Exportateur de Code GraphiQL"
+    },
+    "btn": {
+      "show_plugin": "Afficher {{pluginTitle}}",
+      "hide_plugin": "Masquer {{pluginTitle}}"
+    }
   }
 }

--- a/packages/graphiql-react/src/plugin.tsx
+++ b/packages/graphiql-react/src/plugin.tsx
@@ -27,9 +27,15 @@ export type GraphiQLPlugin = {
    * title the provider component will throw an error.
    */
   title: string;
+  
+  /**
+   * The unique identifier of the plugin.
+   */
+  id: string;
 };
 
 export const DOC_EXPLORER_PLUGIN: GraphiQLPlugin = {
+  id: 'documentation_explorer',
   title: 'Documentation Explorer',
   icon: function Icon() {
     const pluginContext = usePluginContext();
@@ -42,6 +48,7 @@ export const DOC_EXPLORER_PLUGIN: GraphiQLPlugin = {
   content: DocExplorer,
 };
 export const HISTORY_PLUGIN: GraphiQLPlugin = {
+  id: 'history',
   title: 'History',
   icon: HistoryIcon,
   content: History,

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -556,7 +556,9 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
           <div className="graphiql-sidebar-section">
             {pluginContext?.plugins.map((plugin, index) => {
               const isVisible = plugin === pluginContext.visiblePlugin;
-              const label = `${isVisible ? 'Hide' : 'Show'} ${plugin.title}`;
+              const pluginTitle = translationService.translate(`plugin.${plugin.id}.title`, currentLanguage);
+              const labelKey = 'plugin.btn.' + (isVisible ? 'hide_plugin' : 'show_plugin');
+              const label = translationService.translate(labelKey, currentLanguage, {pluginTitle});
               return (
                 <Tooltip key={plugin.title} label={label}>
                   <UnStyledButton


### PR DESCRIPTION
## What
Added translations for the plugin buttons in the graphiql sidebar.

## Why
All labels must be internationalized.

## How
- Extended the GraphiQLPlugin type with a new property id, which is used to calculate the label key for translation.
- Refactored the logic for button creation to use translated labels instead of hardcoded plugin names.