### PR TITLE
GDB-11239: Internationalize the Documentation Explorer Plugin

### DIFF
--- a/packages/graphiql-react/src/assets/i18n/en.json
+++ b/packages/graphiql-react/src/assets/i18n/en.json
@@ -115,7 +115,73 @@
       "title": "History"
     },
     "documentation_explorer": {
-      "title": "Documentation Explorer"
+      "title": "Documentation Explorer",
+      "section": {
+        "root_types": {
+          "title": "Root Types"
+        },
+        "fields": {
+          "title": "Fields"
+        },
+        "deprecated_fields": {
+          "title": "Deprecated Fields"
+        },
+        "type": {
+          "title": "Type"
+        },
+        "arguments": {
+          "title": "Arguments"
+        },
+        "deprecated_arguments": {
+          "title": "Deprecated Arguments"
+        },
+        "implements": {
+          "title": "Implements"
+        },
+        "implementations": {
+          "title": "Implementations"
+        },
+        "possible_types": {
+          "title": "Possible Types"
+        },
+        "enum_values": {
+          "title": "Enum Values"
+        },
+        "deprecated_enum_values": {
+          "title": "Deprecated Enum Values"
+        },
+        "directives": {
+          "title": "Directives"
+        },
+        "all_schema_types": {
+          "title": "All Schema Types"
+        }
+      },
+      "root_type": {
+        "default_description": "A GraphQL schema provides a root type for each kind of operation.",
+        "query": "query",
+        "mutation": "mutation",
+        "subscription": "subscription"
+      },
+      "argument": {
+        "deprecated": "Deprecated"
+      },
+      "deprecation_reason": {
+        "deprecated": "Deprecated"
+      },
+      "search": {
+        "no_result_found": "No results found",
+        "other_results": "Other results"
+      },
+      "btn": {
+        "show_deprecated_arguments": "Show Deprecated Arguments",
+        "show_deprecated_fields": "Show Deprecated Fields"
+      },
+      "error": {
+        "fetching_schema": "Error fetching schema",
+        "invalid_schema": "Schema is invalid: {{errorMessage}}",
+        "schema_not_available": "No GraphQL schema available"
+      }
     },
     "graphiql_explorer": {
       "title": "GraphiQL Explorer"

--- a/packages/graphiql-react/src/assets/i18n/fr.json
+++ b/packages/graphiql-react/src/assets/i18n/fr.json
@@ -115,7 +115,73 @@
       "title": "Historique"
     },
     "documentation_explorer": {
-      "title": "Explorateur de documentation"
+      "title": "Explorateur de documentation",
+      "section": {
+        "root_types": {
+          "title": "Types Racines"
+        },
+        "fields": {
+          "title": "Champs"
+        },
+        "deprecated_fields": {
+          "title": "Champs Obsolètes"
+        },
+        "type": {
+          "title": "Type"
+        },
+        "arguments": {
+          "title": "Arguments"
+        },
+        "deprecated_arguments": {
+          "title": "Arguments Obsolètes"
+        },
+        "implements": {
+          "title": "Implémente"
+        },
+        "implementations": {
+          "title": "Implémentations"
+        },
+        "possible_types": {
+          "title": "Types Possibles"
+        },
+        "enum_values": {
+          "title": "Valeurs Enum"
+        },
+        "deprecated_enum_values": {
+          "title": "Valeurs Enum Obsolètes"
+        },
+        "directives": {
+          "title": "Directives"
+        },
+        "all_schema_types": {
+          "title": "Tous les Types de Schéma"
+        }
+      },
+      "root_type": {
+        "default_description": "Un schéma GraphQL fournit un type racine pour chaque type d'opération.",
+        "query": "requête",
+        "mutation": "mutation",
+        "subscription": "abonnement"
+      },
+      "argument": {
+        "deprecated": "Obsolète"
+      },
+      "deprecation_reason": {
+        "deprecated": "Obsolète"
+      },
+      "search": {
+        "no_result_found": "Aucun résultat trouvé",
+        "other_results": "Autres résultats"
+      },
+      "btn": {
+        "show_deprecated_arguments": "Afficher les arguments obsolètes",
+        "show_deprecated_fields": "Afficher les champs obsolètes"
+      },
+      "error": {
+        "fetching_schema": "Erreur lors de la récupération du schéma",
+        "invalid_schema": "Le schéma est invalide : {{errorMessage}}",
+        "schema_not_available": "Aucun schéma GraphQL disponible"
+      }
     },
     "graphiql_explorer": {
       "title": "Explorateur GraphiQL"

--- a/packages/graphiql-react/src/explorer/components/argument.tsx
+++ b/packages/graphiql-react/src/explorer/components/argument.tsx
@@ -5,6 +5,7 @@ import { TypeLink } from './type-link';
 
 import './argument.css';
 import { MarkdownContent } from '../../ui';
+import {TranslateText} from '../../translation';
 
 type ArgumentProps = {
   /**
@@ -46,7 +47,7 @@ export function Argument({ arg, showDefaultValue, inline }: ArgumentProps) {
       {arg.deprecationReason ? (
         <div className="graphiql-doc-explorer-argument-deprecation">
           <div className="graphiql-doc-explorer-argument-deprecation-label">
-            Deprecated
+            <TranslateText translationKey="plugin.documentation_explorer.argument.deprecated"/>
           </div>
           <MarkdownContent type="deprecation">
             {arg.deprecationReason}

--- a/packages/graphiql-react/src/explorer/components/deprecation-reason.tsx
+++ b/packages/graphiql-react/src/explorer/components/deprecation-reason.tsx
@@ -1,6 +1,7 @@
 import { MarkdownContent } from '../../ui';
 
 import './deprecation-reason.css';
+import {TranslateText} from '../../translation';
 
 type DeprecationReasonProps = {
   /**
@@ -13,7 +14,9 @@ type DeprecationReasonProps = {
 export function DeprecationReason(props: DeprecationReasonProps) {
   return props.children ? (
     <div className="graphiql-doc-explorer-deprecation">
-      <div className="graphiql-doc-explorer-deprecation-label">Deprecated</div>
+      <div className="graphiql-doc-explorer-deprecation-label">
+        <TranslateText translationKey="plugin.documentation_explorer.deprecation_reason.deprecated"/>
+      </div>
       <MarkdownContent
         type="deprecation"
         onlyShowFirstChild={props.preview ?? true}

--- a/packages/graphiql-react/src/explorer/components/doc-explorer.tsx
+++ b/packages/graphiql-react/src/explorer/components/doc-explorer.tsx
@@ -11,6 +11,7 @@ import { Search } from './search';
 import { TypeDocumentation } from './type-documentation';
 
 import './doc-explorer.css';
+import {TranslateText} from '../../translation';
 
 export function DocExplorer() {
   const { fetchError, isFetching, schema, validationErrors } = useSchemaContext(
@@ -26,12 +27,15 @@ export function DocExplorer() {
   let content: ReactNode = null;
   if (fetchError) {
     content = (
-      <div className="graphiql-doc-explorer-error">Error fetching schema</div>
+      <div className="graphiql-doc-explorer-error">
+        <TranslateText translationKey="plugin.documentation_explorer.error.fetching_schema"/>
+      </div>
     );
   } else if (validationErrors.length > 0) {
     content = (
       <div className="graphiql-doc-explorer-error">
-        Schema is invalid: {validationErrors[0].message}
+        <TranslateText translationKey="plugin.documentation_explorer.error.invalid_schema"
+                       translationParams={{errorMessage: validationErrors[0].message}}/>
       </div>
     );
   } else if (isFetching) {
@@ -42,7 +46,7 @@ export function DocExplorer() {
     // an error during introspection.
     content = (
       <div className="graphiql-doc-explorer-error">
-        No GraphQL schema available
+        <TranslateText translationKey="plugin.documentation_explorer.error.schema_not_available"/>
       </div>
     );
   } else if (explorerNavStack.length === 1) {

--- a/packages/graphiql-react/src/explorer/components/field-documentation.tsx
+++ b/packages/graphiql-react/src/explorer/components/field-documentation.tsx
@@ -8,6 +8,7 @@ import { DeprecationReason } from './deprecation-reason';
 import { Directive } from './directive';
 import { ExplorerSection } from './section';
 import { TypeLink } from './type-link';
+import {TranslateText} from '../../translation';
 
 type FieldDocumentationProps = {
   /**
@@ -74,7 +75,7 @@ function Arguments({ field }: { field: ExplorerFieldDef }) {
           </ExplorerSection>
         ) : (
           <Button type="button" onClick={handleShowDeprecated}>
-            Show Deprecated Arguments
+            <TranslateText translationKey="plugin.documentation_explorer.btn.show_deprecated_arguments"/>
           </Button>
         )
       ) : null}

--- a/packages/graphiql-react/src/explorer/components/schema-documentation.tsx
+++ b/packages/graphiql-react/src/explorer/components/schema-documentation.tsx
@@ -5,6 +5,7 @@ import { ExplorerSection } from './section';
 import { TypeLink } from './type-link';
 
 import './schema-documentation.css';
+import {TranslateText} from '../../translation';
 
 type SchemaDocumentationProps = {
   /**
@@ -26,21 +27,28 @@ export function SchemaDocumentation(props: SchemaDocumentationProps) {
 
   return (
     <>
-      <MarkdownContent type="description">
-        {props.schema.description ||
-          'A GraphQL schema provides a root type for each kind of operation.'}
-      </MarkdownContent>
+      {props.schema.description ?
+        <MarkdownContent type="description">{props.schema.description}</MarkdownContent>
+        :
+        <div>
+          <TranslateText translationKey="plugin.documentation_explorer.root_type.default_description"/>
+        </div>
+      }
       <ExplorerSection title="Root Types">
         {queryType ? (
           <div>
-            <span className="graphiql-doc-explorer-root-type">query</span>
+            <span className="graphiql-doc-explorer-root-type">
+              <TranslateText translationKey="plugin.documentation_explorer.root_type.query"/>
+            </span>
             {': '}
             <TypeLink type={queryType} />
           </div>
         ) : null}
         {mutationType && (
           <div>
-            <span className="graphiql-doc-explorer-root-type">mutation</span>
+            <span className="graphiql-doc-explorer-root-type">
+              <TranslateText translationKey="plugin.documentation_explorer.root_type.mutation"/>
+            </span>
             {': '}
             <TypeLink type={mutationType} />
           </div>
@@ -48,7 +56,7 @@ export function SchemaDocumentation(props: SchemaDocumentationProps) {
         {subscriptionType && (
           <div>
             <span className="graphiql-doc-explorer-root-type">
-              subscription
+              <TranslateText translationKey="plugin.documentation_explorer.root_type.subscription"/>
             </span>
             {': '}
             <TypeLink type={subscriptionType} />

--- a/packages/graphiql-react/src/explorer/components/search.tsx
+++ b/packages/graphiql-react/src/explorer/components/search.tsx
@@ -25,6 +25,7 @@ import { useExplorerContext } from '../context';
 import './search.css';
 import { renderType } from './utils';
 import { isMacOs } from '../../utility/is-macos';
+import {TranslateText} from '../../translation';
 
 export function Search() {
   const { explorerNavStack, push } = useExplorerContext({
@@ -119,7 +120,7 @@ export function Search() {
             results.fields.length ===
           0 ? (
             <li className="graphiql-doc-explorer-search-empty">
-              No results found
+              <TranslateText translationKey='plugin.documentation_explorer.search.no_result_found'/>
             </li>
           ) : (
             results.within.map((result, i) => (
@@ -135,7 +136,7 @@ export function Search() {
           {results.within.length > 0 &&
           results.types.length + results.fields.length > 0 ? (
             <div className="graphiql-doc-explorer-search-divider">
-              Other results
+              <TranslateText translationKey='plugin.documentation_explorer.search.other_results'/>
             </div>
           ) : null}
           {results.types.map((result, i) => (

--- a/packages/graphiql-react/src/explorer/components/section.tsx
+++ b/packages/graphiql-react/src/explorer/components/section.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../icons';
 
 import './section.css';
+import {TranslateText} from '../../translation';
 
 type ExplorerSectionProps = {
   children: ReactNode;
@@ -43,7 +44,7 @@ export function ExplorerSection(props: ExplorerSectionProps) {
     <div>
       <div className="graphiql-doc-explorer-section-title">
         <Icon />
-        {props.title}
+        <TranslateText translationKey={`plugin.documentation_explorer.section.${normalizeJsonKey(props.title)}.title`}/>
       </div>
       <div className="graphiql-doc-explorer-section-content">
         {props.children}
@@ -66,4 +67,21 @@ const TYPE_TO_ICON: Record<ExplorerSectionProps['title'], ComponentType> = {
   'Root Types': RootTypeIcon,
   Type: TypeIcon,
   'All Schema Types': TypeIcon,
+};
+
+/**
+ * Converts a given string into a normalized JSON key by replacing spaces with underscores and converting it to lowercase.
+ *
+ * @param key - The input string to normalize.
+ * @returns A normalized string suitable for use as a JSON key.
+ *
+ * @example
+ * ```typescript
+ * normalizeJsonKey("Root Types"); // "root_types"
+ * normalizeJsonKey("Enum Values"); // "enum_values"
+ * normalizeJsonKey("  Deprecated Fields  "); // "deprecated_fields"
+ * ```
+ */
+const normalizeJsonKey = (key = ''): string => {
+  return key.trim().replaceAll(' ', '_').toLowerCase();
 };

--- a/packages/graphiql-react/src/explorer/components/type-documentation.tsx
+++ b/packages/graphiql-react/src/explorer/components/type-documentation.tsx
@@ -21,6 +21,7 @@ import { ExplorerSection } from './section';
 import { TypeLink } from './type-link';
 
 import './type-documentation.css';
+import {TranslateText} from '../../translation';
 
 type TypeDocumentationProps = {
   /**
@@ -106,7 +107,7 @@ function Fields({ type }: { type: GraphQLNamedType }) {
           </ExplorerSection>
         ) : (
           <Button type="button" onClick={handleShowDeprecated}>
-            Show Deprecated Fields
+            <TranslateText translationKey='plugin.documentation_explorer.btn.show_deprecated_fields'/>
           </Button>
         )
       ) : null}


### PR DESCRIPTION
## What
Added internationalization to the Documentation Explorer plugin.

## Why
All GraphiQL components must be internationalized.

## How
 - Moved hardcoded labels to translation bundles;
 - Updated the plugin component to fetch translations dynamically based on the selected language.