### PR TITLE
GDB-11239: Internationalize the History Plugin

### DIFF
--- a/packages/graphiql-react/src/assets/i18n/en.json
+++ b/packages/graphiql-react/src/assets/i18n/en.json
@@ -43,6 +43,16 @@
           "tooltip": "Stop query (Ctrl-Enter)"
         }
       }
+    },
+    "tab": {
+      "btn": {
+        "close_tab": {
+          "tooltip": "Close tab"
+        },
+        "add_tab": {
+          "tooltip": "Add tab"
+        }
+      }
     }
   },
   "dialog": {
@@ -103,16 +113,35 @@
       "footer": "The editors use <a href=\"https://codemirror.net/5/doc/manual.html#keymaps\" target=\"_blank\" rel=\"noopener noreferrer\" >CodeMirror Key Maps</a> that add more short keys. This instance of Graph<em>i</em>QL uses <code>{{keyMap}}</code>."
     }
   },
-  "component": {
-    "add_tab": {
-      "btn": {
-        "tooltip": "Add tab"
-      }
-    }
-  },
   "plugin": {
     "history": {
-      "title": "History"
+      "title": "History",
+      "name": {
+        "placeholder": "Type a label",
+        "tooltip": "Set active"
+      },
+      "btn": {
+        "save": "Save",
+        "edit_label": {
+          "tooltip": "Edit label"
+        },
+        "add_favorite": {
+          "tooltip": "Add favorite"
+        },
+        "remove_favorite": {
+          "tooltip": "Remove favorite"
+        },
+        "delete_from_history": {
+          "tooltip": "Delete from history"
+        },
+        "clear": {
+          "label": "Clear",
+          "status": {
+            "cleared": "Cleared",
+            "failed_to_clear": "Failed to Clear"
+          }
+        }
+      }
     },
     "documentation_explorer": {
       "title": "Documentation Explorer",

--- a/packages/graphiql-react/src/assets/i18n/fr.json
+++ b/packages/graphiql-react/src/assets/i18n/fr.json
@@ -43,6 +43,16 @@
           "tooltip": "Arrêter la requête (Ctrl-Entrée)"
         }
       }
+    },
+    "tab": {
+      "btn": {
+        "close_tab": {
+          "tooltip": "Fermer l'onglet"
+        },
+        "add_tab": {
+          "tooltip": "Ajouter un onglet"
+        }
+      }
     }
   },
   "dialog": {
@@ -103,16 +113,35 @@
       "footer": "Les éditeurs utilisent les <a href=\"https://codemirror.net/5/doc/manual.html#keymaps\" target=\"_blank\" rel=\"noopener noreferrer\">mappages de touches de CodeMirror</a>, qui ajoutent davantage de raccourcis clavier. Cette instance de Graph<em>i</em>QL utilise <code>{{keyMap}}</code>."
     }
   },
-  "component": {
-    "add_tab": {
-      "btn": {
-        "tooltip": "Ajouter un onglet"
-      }
-    }
-  },
   "plugin": {
     "history": {
-      "title": "Historique"
+      "title": "Historique",
+      "name": {
+        "placeholder": "Saisissez une étiquette",
+        "tooltip": "Définir comme actif"
+      },
+      "btn": {
+        "save": "Enregistrer",
+        "edit_label": {
+          "tooltip": "Modifier l'étiquette"
+        },
+        "add_favorite": {
+          "tooltip": "Ajouter aux favoris"
+        },
+        "remove_favorite": {
+          "tooltip": "Retirer des favoris"
+        },
+        "delete_from_history": {
+          "tooltip": "Supprimer de l'historique"
+        },
+        "clear": {
+          "label": "Effacer",
+          "status": {
+            "cleared": "Effacé",
+            "failed_to_clear": "Échec de l'effacement"
+          }
+        }
+      }
     },
     "documentation_explorer": {
       "title": "Explorateur de documentation",

--- a/packages/graphiql-react/src/history/components.tsx
+++ b/packages/graphiql-react/src/history/components.tsx
@@ -1,7 +1,7 @@
 import type { QueryStoreItem } from '@graphiql/toolkit';
 import {
   MouseEventHandler,
-  useCallback,
+  useCallback, useContext,
   useEffect,
   useRef,
   useState,
@@ -20,6 +20,7 @@ import { Button, Tooltip, UnStyledButton } from '../ui';
 import { useHistoryContext } from './context';
 
 import './style.css';
+import {TranslateText, TranslationContext} from '../translation';
 
 export function History() {
   const { items: all, deleteFromHistory } = useHistoryContext({
@@ -59,11 +60,13 @@ export function History() {
       setClearStatus('error');
     }
   }, [deleteFromHistory, items]);
+  
+  const { currentLanguage, translationService } = useContext(TranslationContext);
 
   return (
-    <section aria-label="History" className="graphiql-history">
+    <section aria-label={translationService.translate('plugin.history.title', currentLanguage)} className="graphiql-history">
       <div className="graphiql-history-header">
-        History
+        <TranslateText translationKey='plugin.history.title'/>
         {(clearStatus || items.length > 0) && (
           <Button
             type="button"
@@ -72,9 +75,9 @@ export function History() {
             onClick={handleClearStatus}
           >
             {{
-              success: 'Cleared',
-              error: 'Failed to Clear',
-            }[clearStatus!] || 'Clear'}
+              success: translationService.translate('plugin.history.btn.clear.status.cleared', currentLanguage),
+              error: translationService.translate('plugin.history.btn.clear.status.failed_to_clear', currentLanguage),
+            }[clearStatus!] || <TranslateText translationKey='plugin.history.btn.clear.label'/>}
           </Button>
         )}
       </div>
@@ -175,7 +178,14 @@ export function HistoryItem(props: QueryHistoryItemProps) {
       },
       [props.item, toggleFavorite],
     );
-
+  
+  const { currentLanguage, translationService } = useContext(TranslationContext);
+  
+  const pluginTitle = translationService.translate('plugin.history.name.tooltip', currentLanguage);
+  const btnEditLabel = translationService.translate('plugin.history.btn.edit_label.tooltip', currentLanguage);
+  const btnFavoriteTooltip = translationService.translate(props.item.favorite ? 'plugin.history.btn.remove_favorite.tooltip' : 'plugin.history.btn.add_favorite.tooltip', currentLanguage);
+  const btnDeleteFromTooltip = translationService.translate('plugin.history.btn.delete_from_history.tooltip', currentLanguage);
+  
   return (
     <li className={clsx('graphiql-history-item', isEditable && 'editable')}>
       {isEditable ? (
@@ -192,10 +202,10 @@ export function HistoryItem(props: QueryHistoryItemProps) {
                 editLabel({ ...props.item, label: e.currentTarget.value });
               }
             }}
-            placeholder="Type a label"
+            placeholder={translationService.translate('plugin.history.name.placeholder', currentLanguage)}
           />
           <UnStyledButton type="button" ref={buttonRef} onClick={handleSave}>
-            Save
+            <TranslateText translationKey='plugin.history.btn.save'/>
           </UnStyledButton>
           <UnStyledButton type="button" ref={buttonRef} onClick={handleClose}>
             <CloseIcon />
@@ -203,36 +213,34 @@ export function HistoryItem(props: QueryHistoryItemProps) {
         </>
       ) : (
         <>
-          <Tooltip label="Set active">
+          <Tooltip label={pluginTitle}>
             <UnStyledButton
               type="button"
               className="graphiql-history-item-label"
               onClick={handleHistoryItemClick}
-              aria-label="Set active"
+              aria-label={pluginTitle}
             >
               {displayName}
             </UnStyledButton>
           </Tooltip>
-          <Tooltip label="Edit label">
+          <Tooltip label={btnEditLabel}>
             <UnStyledButton
               type="button"
               className="graphiql-history-item-action"
               onClick={handleEditLabel}
-              aria-label="Edit label"
+              aria-label={btnEditLabel}
             >
               <PenIcon aria-hidden="true" />
             </UnStyledButton>
           </Tooltip>
           <Tooltip
-            label={props.item.favorite ? 'Remove favorite' : 'Add favorite'}
+            label={btnFavoriteTooltip}
           >
             <UnStyledButton
               type="button"
               className="graphiql-history-item-action"
               onClick={handleToggleFavorite}
-              aria-label={
-                props.item.favorite ? 'Remove favorite' : 'Add favorite'
-              }
+              aria-label={btnFavoriteTooltip}
             >
               {props.item.favorite ? (
                 <StarFilledIcon aria-hidden="true" />
@@ -241,12 +249,12 @@ export function HistoryItem(props: QueryHistoryItemProps) {
               )}
             </UnStyledButton>
           </Tooltip>
-          <Tooltip label="Delete from history">
+          <Tooltip label={btnDeleteFromTooltip}>
             <UnStyledButton
               type="button"
               className="graphiql-history-item-action"
               onClick={handleDeleteItemFromHistory}
-              aria-label="Delete from history"
+              aria-label={btnDeleteFromTooltip}
             >
               <TrashIcon aria-hidden="true" />
             </UnStyledButton>

--- a/packages/graphiql-react/src/ui/tabs.tsx
+++ b/packages/graphiql-react/src/ui/tabs.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ReactNode } from 'react';
+import {forwardRef, ReactNode, useContext} from 'react';
 import { clsx } from 'clsx';
 import { Reorder } from 'framer-motion';
 import { CloseIcon } from '../icons';
@@ -7,6 +7,7 @@ import { UnStyledButton } from './button';
 import { Tooltip } from './tooltip';
 
 import './tabs.css';
+import {TranslationContext} from '../translation';
 
 type TabProps = {
   isActive?: boolean;
@@ -51,10 +52,15 @@ const TabButton = forwardRef<
 TabButton.displayName = 'Tab.Button';
 
 const TabClose = forwardRef<HTMLButtonElement, JSX.IntrinsicElements['button']>(
-  (props, ref) => (
-    <Tooltip label="Close Tab">
+  (props, ref) => {
+    
+    const { currentLanguage, translationService } = useContext(TranslationContext);
+    const btnCloseTabeTooltip = translationService.translate('graphiql.tab.btn.close_tab.tooltip', currentLanguage);
+    
+    return (
+    <Tooltip label={btnCloseTabeTooltip}>
       <UnStyledButton
-        aria-label="Close Tab"
+        aria-label={btnCloseTabeTooltip}
         {...props}
         ref={ref}
         type="button"
@@ -63,7 +69,7 @@ const TabClose = forwardRef<HTMLButtonElement, JSX.IntrinsicElements['button']>(
         <CloseIcon />
       </UnStyledButton>
     </Tooltip>
-  ),
+  )},
 );
 TabClose.displayName = 'Tab.Close';
 

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -486,7 +486,7 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
   }, []);
 
   const addTabLabel = translationService.translate(
-    'component.add_tab.btn.tooltip',
+    'graphiql.tab.btn.add_tab.tooltip',
     currentLanguage,
   );
   const addTab = (


### PR DESCRIPTION
## What
Added internationalization to the History plugin.

## Why
All GraphiQL components must be internationalized.

## How
 - Moved hardcoded labels to translation bundles;
 - Updated the plugin component to fetch translations dynamically based on the selected language.

### Additional work
Added translation to close tab button tooltip