### PR TITLE
GDB-11239: Internationalize the Default Tag Title

### DIFF
--- a/packages/graphiql-react/src/assets/i18n/en.json
+++ b/packages/graphiql-react/src/assets/i18n/en.json
@@ -45,6 +45,7 @@
       }
     },
     "tab": {
+      "default_title": "<untitled>",
       "btn": {
         "close_tab": {
           "tooltip": "Close tab"

--- a/packages/graphiql-react/src/assets/i18n/fr.json
+++ b/packages/graphiql-react/src/assets/i18n/fr.json
@@ -45,6 +45,7 @@
       }
     },
     "tab": {
+      "default_title": "<sans titre>",
       "btn": {
         "close_tab": {
           "tooltip": "Fermer l'onglet"

--- a/packages/graphiql-react/src/editor/context.tsx
+++ b/packages/graphiql-react/src/editor/context.tsx
@@ -10,6 +10,7 @@ import { VariableToType } from 'graphql-language-service';
 import {
   ReactNode,
   useCallback,
+  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -37,6 +38,7 @@ import {
 } from './tabs';
 import { CodeMirrorEditor } from './types';
 import { STORAGE_KEY as STORAGE_KEY_VARIABLES } from './variable-editor';
+import {TranslationContext} from '../translation';
 
 export type CodeMirrorEditorWithOperationFacts = CodeMirrorEditor & {
   documentAST: DocumentNode | null;
@@ -294,6 +296,8 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
     shouldPersistHeaders,
   });
 
+  const { currentLanguage, translationService } = useContext(TranslationContext);
+
   // We store this in state but never update it. By passing a function we only
   // need to compute it lazily during the initial render.
   const [initialState] = useState(() => {
@@ -379,6 +383,7 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
           createTab({
             headers: defaultHeaders,
             query: defaultQuery ?? DEFAULT_QUERY,
+            defaultTabTitle: translationService.translate('graphiql.tab.default_title', currentLanguage),
           }),
         ],
         activeTabIndex: updatedValues.tabs.length,
@@ -395,6 +400,7 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
     setEditorValues,
     storeTabs,
     synchronizeActiveTabValues,
+    currentLanguage
   ]);
 
   const changeTab = useCallback<EditorContextType['changeTab']>(

--- a/packages/graphiql-react/src/editor/tabs.ts
+++ b/packages/graphiql-react/src/editor/tabs.ts
@@ -18,6 +18,8 @@ export type TabDefinition = {
    * The contents of the headers editor of this tab.
    */
   headers?: string | null;
+  
+  defaultTabTitle?: string
 };
 
 /**
@@ -73,6 +75,7 @@ export function getDefaultTabState({
   variables,
   storage,
   shouldPersistHeaders,
+  defaultTabTitle
 }: {
   defaultQuery: string;
   defaultHeaders?: string;
@@ -82,6 +85,7 @@ export function getDefaultTabState({
   variables: string | null;
   storage: StorageAPI | null;
   shouldPersistHeaders?: boolean;
+  defaultTabTitle?: string;
 }) {
   const storedState = storage?.get(STORAGE_KEY);
   try {
@@ -119,7 +123,7 @@ export function getDefaultTabState({
         parsed.tabs.push({
           id: guid(),
           hash: expectedHash,
-          title: operationName || DEFAULT_TITLE,
+          title: operationName || defaultTabTitle || DEFAULT_TITLE,
           query,
           variables,
           headers,
@@ -291,11 +295,12 @@ export function createTab({
   query = null,
   variables = null,
   headers = null,
+  defaultTabTitle = undefined
 }: Partial<TabDefinition> = {}): TabState {
   return {
     id: guid(),
     hash: hashFromTabContents({ query, variables, headers }),
-    title: (query && fuzzyExtractOperationName(query)) || DEFAULT_TITLE,
+    title: (query && fuzzyExtractOperationName(query)) || defaultTabTitle || DEFAULT_TITLE,
     query,
     variables,
     headers,
@@ -323,6 +328,7 @@ export function setPropertiesInActiveTab(
           (newTab.query
             ? fuzzyExtractOperationName(newTab.query)
             : undefined) ||
+          newTab.title ||
           DEFAULT_TITLE,
       };
     }),

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -146,6 +146,7 @@ export function GraphiQL({
   }
 
   return (
+    <TranslationProvider {...props}>
     <GraphiQLProvider
       getDefaultFieldNames={getDefaultFieldNames}
       dangerouslyAssumeSchemaIsValid={dangerouslyAssumeSchemaIsValid}
@@ -174,7 +175,7 @@ export function GraphiQL({
       validationRules={validationRules}
       variables={variables}
     >
-      <TranslationProvider {...props}>
+        
         <GraphiQLInterface
           confirmCloseTab={confirmCloseTab}
           showPersistHeadersSettings={shouldPersistHeaders !== false}
@@ -182,8 +183,8 @@ export function GraphiQL({
           forcedTheme={props.forcedTheme}
           {...props}
         />
-      </TranslationProvider>
     </GraphiQLProvider>
+    </TranslationProvider>
   );
 }
 


### PR DESCRIPTION
## What
Added internationalization for the default tag title.

## Why
All GraphiQL components must be internationalized.

## How
Extended the editor context to use the translation service for translating the default tag name.

![image](https://github.com/user-attachments/assets/1ce42298-fa11-41ee-a12f-b6bb651ac0ed)
