### PR TITLE
GDB-11239: Extend GraphiQLProviderProps with newly added translation properties

### DIFF
--- a/packages/graphiql-react/src/provider.tsx
+++ b/packages/graphiql-react/src/provider.tsx
@@ -11,6 +11,7 @@ import { HistoryContextProvider, HistoryContextProviderProps } from './history';
 import { PluginContextProvider, PluginContextProviderProps } from './plugin';
 import { SchemaContextProvider, SchemaContextProviderProps } from './schema';
 import { StorageContextProvider, StorageContextProviderProps } from './storage';
+import {TranslationContextProviderProps} from './translation/models/translation-context-provider-props';
 
 export type GraphiQLProviderProps = EditorContextProviderProps &
   ExecutionContextProviderProps &
@@ -18,7 +19,8 @@ export type GraphiQLProviderProps = EditorContextProviderProps &
   HistoryContextProviderProps &
   PluginContextProviderProps &
   SchemaContextProviderProps &
-  StorageContextProviderProps;
+  StorageContextProviderProps &
+  TranslationContextProviderProps;
 
 export function GraphiQLProvider({
   children,

--- a/packages/graphiql-react/src/translation/models/translation-context-provider-props.ts
+++ b/packages/graphiql-react/src/translation/models/translation-context-provider-props.ts
@@ -1,0 +1,32 @@
+import {Translations} from './translations';
+
+export type TranslationContextProviderProps = {
+  /**
+   * Determined the language that has to be used.
+   */
+  selectedLanguage?: string
+  
+  /**
+   * Represents a collection of translations for multiple languages,
+   * using a flat structure with dot-separated keys or nested objects.
+   *
+   * @example
+   * ```typescript
+   * const translations: Translations = {
+   *   en: {
+   *     "editor.title": "Editor",
+   *     "editor": {
+   *       "description": "This is the editor"
+   *     }
+   *   },
+   *   fr: {
+   *     "editor.title": "Éditeur",
+   *     "editor": {
+   *       "description": "C'est l'éditeur"
+   *     }
+   *   }
+   * };
+   * ```
+   */
+  translations?: Translations;
+}


### PR DESCRIPTION
## What
 Extend the GraphiQLProviderProps with newly added translation properties.

## Why
By providing translation to GraphiQL, the properties that can be passed to it have increased to include "selectedLanguage" and "translations."

## How
Create a type definition for the translation provider's properties and add it to the GraphiQL provider's properties.