### PR TITLE
GDB-11741: Add Query Aborting Functionality

### DIFF
--- a/packages/graphiql-toolkit/src/create-fetcher/types.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/types.ts
@@ -33,6 +33,7 @@ export type FetcherParams = {
 export type FetcherOpts = {
   headers?: { [key: string]: any };
   documentAST?: DocumentNode;
+  abortController?: AbortController
 };
 
 export type ExecutionResultPayload =
@@ -99,12 +100,15 @@ export interface CreateFetcherOptions {
    */
   legacyClient?: any;
   /**
-   * Headers you can provide statically.
+   * Headers that can be provided statically or dynamically.
+   *
+   * - If provided as an object (`Record<string, string>`), these headers are set statically.
+   * - If provided as a function (`() => Record<string, string>`), the function will be called to generate the headers dynamically.
    *
    * If you enable the headers editor and the user provides
    * A header you set statically here, it will be overridden by their value.
    */
-  headers?: Record<string, string>;
+  headers?: Record<string, string> | (() => Record<string, string>);
   /**
    * Websockets connection params used when you provide subscriptionUrl. graphql-ws `ClientOptions.connectionParams`
    */
@@ -125,4 +129,11 @@ export interface CreateFetcherOptions {
    * the `url` and `headers` property should have you covered.
    */
   schemaFetcher?: Fetcher;
+  
+  /**
+   * Callback function called when a query is aborted.
+   */
+  onAbortQuery?: (response: RequestInit) => void;
 }
+
+export const ABORT_QUERY = '_abort_query_'


### PR DESCRIPTION
## What
The GraphQL playground has been extended with the ability to cancel a running query and notify about the cancellation. Previously, there was an implementation that "canceled" queries, but it did not actually cancel the request—it only ignored the result. Additionally, there was no notification about the event.

## Why
We need to properly cancel the request and notify the GraphQL playground client when this event occurs so they can take appropriate actions after cancellation.

## How
- The API uses fetch for requests, so I extended the request handling with AbortController, which allows queries to be canceled.
- The CreateFetcherOptions interface was extended with a new property, onAbortQuery, a function that is called when a query is canceled.

### Additional Work
The headers property of CreateFetcherOptions has been extended to support functions as well. If a function is provided, it will be called and must return an object containing headers that will be added to the request.