### PR TITLE
Fix CodeMirror multiple instance issue

### DIFF
--- a/packages/graphiql-react/src/editor/header-editor.ts
+++ b/packages/graphiql-react/src/editor/header-editor.ts
@@ -47,6 +47,7 @@ export function useHeaderEditor(
   const merge = useMergeQuery({ caller: caller || useHeaderEditor });
   const prettify = usePrettifyEditors({ caller: caller || useHeaderEditor });
   const ref = useRef<HTMLDivElement>(null);
+  const initialThemeRef = useRef(editorTheme);
 
   useEffect(() => {
     let isActive = true;
@@ -70,7 +71,7 @@ export function useHeaderEditor(
         lineNumbers: true,
         tabSize: 2,
         mode: { name: 'javascript', json: true },
-        theme: editorTheme,
+        theme: initialThemeRef.current,
         autoCloseBrackets: true,
         matchBrackets: true,
         showCursorWhenSelecting: true,
@@ -110,8 +111,9 @@ export function useHeaderEditor(
     return () => {
       isActive = false;
     };
-  }, [editorTheme, initialHeaders, readOnly, setHeaderEditor]);
+  }, [initialHeaders, readOnly, setHeaderEditor]);
 
+  useSynchronizeOption(headerEditor, 'theme', editorTheme);
   useSynchronizeOption(headerEditor, 'keyMap', keyMap);
 
   useChangeHandler(

--- a/packages/graphiql-react/src/editor/query-editor.ts
+++ b/packages/graphiql-react/src/editor/query-editor.ts
@@ -103,6 +103,7 @@ export function useQueryEditor(
   const merge = useMergeQuery({ caller: caller || useQueryEditor });
   const prettify = usePrettifyEditors({ caller: caller || useQueryEditor });
   const ref = useRef<HTMLDivElement>(null);
+  const initialThemeRef = useRef(editorTheme);
   const codeMirrorRef = useRef<CodeMirrorType>();
 
   const onClickReferenceRef = useRef<
@@ -170,7 +171,7 @@ export function useQueryEditor(
         tabSize: 2,
         foldGutter: true,
         mode: 'graphql',
-        theme: editorTheme,
+        theme: initialThemeRef.current,
         autoCloseBrackets: true,
         matchBrackets: true,
         showCursorWhenSelecting: true,
@@ -281,8 +282,9 @@ export function useQueryEditor(
     return () => {
       isActive = false;
     };
-  }, [editorTheme, initialQuery, readOnly, setQueryEditor]);
+  }, [initialQuery, readOnly, setQueryEditor]);
 
+  useSynchronizeOption(queryEditor, 'theme', editorTheme);
   useSynchronizeOption(queryEditor, 'keyMap', keyMap);
 
   /**

--- a/packages/graphiql-react/src/editor/response-editor.tsx
+++ b/packages/graphiql-react/src/editor/response-editor.tsx
@@ -52,6 +52,7 @@ export function useResponseEditor(
       caller: caller || useResponseEditor,
     });
   const ref = useRef<HTMLDivElement>(null);
+  const initialThemeRef = useRef(editorTheme);
 
   const responseTooltipRef = useRef<ResponseTooltipType | undefined>(
     responseTooltip,
@@ -124,7 +125,7 @@ export function useResponseEditor(
         value: initialResponse,
         lineWrapping: true,
         readOnly: true,
-        theme: editorTheme,
+        theme: initialThemeRef.current,
         mode: 'graphql-results',
         foldGutter: true,
         gutters: ['CodeMirror-foldgutter'],
@@ -139,8 +140,9 @@ export function useResponseEditor(
     return () => {
       isActive = false;
     };
-  }, [editorTheme, initialResponse, setResponseEditor]);
+  }, [initialResponse, setResponseEditor]);
 
+  useSynchronizeOption(responseEditor, 'theme', editorTheme);
   useSynchronizeOption(responseEditor, 'keyMap', keyMap);
 
   useEffect(() => {

--- a/packages/graphiql-react/src/editor/variable-editor.ts
+++ b/packages/graphiql-react/src/editor/variable-editor.ts
@@ -53,6 +53,7 @@ export function useVariableEditor(
   const prettify = usePrettifyEditors({ caller: caller || useVariableEditor });
   const ref = useRef<HTMLDivElement>(null);
   const codeMirrorRef = useRef<CodeMirrorType>();
+  const initialThemeRef = useRef(editorTheme);
 
   useEffect(() => {
     let isActive = true;
@@ -79,7 +80,7 @@ export function useVariableEditor(
         lineNumbers: true,
         tabSize: 2,
         mode: 'graphql-variables',
-        theme: editorTheme,
+        theme: initialThemeRef.current,
         autoCloseBrackets: true,
         matchBrackets: true,
         showCursorWhenSelecting: true,
@@ -130,8 +131,9 @@ export function useVariableEditor(
     return () => {
       isActive = false;
     };
-  }, [editorTheme, initialVariables, readOnly, setVariableEditor]);
+  }, [initialVariables, readOnly, setVariableEditor]);
 
+  useSynchronizeOption(variableEditor, 'theme', editorTheme);
   useSynchronizeOption(variableEditor, 'keyMap', keyMap);
 
   useChangeHandler(


### PR DESCRIPTION
## What
When the CodeMirror editor theme is changed, the editors (header editor, query editor, response editor, and variable editor) create a new instance instead of updating the theme on the existing instance.

## Why
The editorTheme property was added as a dependency to a React useEffect hook that is responsible for creating the CodeMirror instance. As a result, when the theme changes, a new instance is created.

## How
Remove editorTheme from the dependency list of the useEffect hook so that a new instance is not created when the theme changes. Move editorTheme handling to a separate hook that only updates the theme option of the already created CodeMirror instance (useSynchronizeOption).

## Sreenshots

Before
<img width="2430" height="768" alt="image" src="https://github.com/user-attachments/assets/ebb91095-533f-4b47-9eca-352b8e26c91f" />
After
<img width="2430" height="768" alt="image" src="https://github.com/user-attachments/assets/ee6d49e3-af9f-41bd-a17e-0aeec7f0869d" />
